### PR TITLE
petites retouches (bug et infos manquantes composer.json)

### DIFF
--- a/Dispatcher.php
+++ b/Dispatcher.php
@@ -77,8 +77,8 @@ class Dispatcher {
         if (!empty($this->controller) && !empty($this->method)) {
             // controller instanciation
             $controller = new $this->controller();
-            // method call
-            $controller->{$this->method}($this->params);
+            // method call with arguments unpacking
+            $controller->{$this->method}(...array_values($this->params));
         }
         else {
             throw new \Exception('Cannot dispatch : controller or method is empty');

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,10 @@
 {
     "name": "benoclock/alto-dispatcher",
+    "version": "1.0.0",
     "description": "AltoDispatcher is a simple and easy-to-use class for dispatching after AltoRouter routing",
     "type": "library",
     "require": {
+        "php": ">=5.6.0",
         "altorouter/altorouter": "^1.2"
     },
     "license": "MIT",
@@ -12,5 +14,8 @@
             "email": "benjamin@oclock.io"
         }
     ],
+    "autoload": {
+        "classmap": ["Dispatcher.php"]
+    },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
Hey Ben, j'ai réglé quelques petits trucs :
- Ce dont on avait parlé au niveau du composer.json. Enfin je crois, faudra encore tester mais a priori, tant que tu ne mets pas de chaîne de version, Composer considère ton package en stabilité minimale (dev). Du coup, il claque une erreur au require :
`Could not find a version of package benoclock/alto-dispatcher matching your minimum-stability (stable). Require it with an explicit version constraint allowing its desired stability.`
- J'en ai profité pour ajouter l'autoload qui manquait aussi et un require php>5.6.0 lié au bug décrit ci-dessous
- Un bug dans le dispatch(), si la méthode du contrôleur attend plusieurs paramètres, ils sont en fait tous passés dans un array en premier (et seul) argument à la méthode. Un opérateur de décomposition et c'est réglé. Comme c'est une "nouveauté" PHP 5.6, je l'ai ajouté au composer.json
Mariska Hargitay :pray: