### PR TITLE
Proposition de gestion de la 404 par le Dispatcher

### DIFF
--- a/Dispatcher.php
+++ b/Dispatcher.php
@@ -19,7 +19,8 @@ class Dispatcher {
     /**
      * Constructor method
      *
-     * @param array $match Array returned by AltoRouter::match()
+     * @param mixed $match Array returned by AltoRouter::match()
+     * @param string|array $fourOFourAction A valid target for the 404 action
      */
     public function __construct($match, $fourOFourAction) {
         // if no route were matched, trigger the 404 action by parsing it so it is called by a later dispatch()

--- a/Dispatcher.php
+++ b/Dispatcher.php
@@ -4,7 +4,7 @@ class Dispatcher {
     /**
      * @var string[]
      */
-    private $params;
+    private $params = [];
 
     /**
      * @var string
@@ -21,35 +21,49 @@ class Dispatcher {
      *
      * @param array $match Array returned by AltoRouter::match()
      */
-    public function __construct($match) {
+    public function __construct($match, $fourOFourAction) {
+        // if no route were matched, trigger the 404 action by parsing it so it is called by a later dispatch()
+        if (!$match) {
+            header('HTTP/1.0 404 Not Found');
+            $this->parseTarget($fourOFourAction);
+            return;
+        }
+
         // Getting DISPATCH infos provided by AltoRouter
-        $dispatchInfos = $match['target'];
+        $this->parseTarget($match['target']);
         
         // Getting URL params (dynamic parts in routes' URL pattern)
         $this->params = $match['params'];
-        
+    }
+
+    /**
+     * Parses the target into valid controller and method properties
+     *
+     * @param string|array $target
+     * @return void
+     */
+    public function parseTarget($target) {
         // Getting controller's name and method's name
         // if it's an array
-        if (is_array($dispatchInfos)) {
-            if (!empty($dispatchInfos['controller']) && !empty($dispatchInfos['method'])) {
-                // Getting
-                $this->controller = $dispatchInfos['controller'];
-                $this->method = $dispatchInfos['method'];
+        if (is_array($target)) {
+            if (!empty($target['controller']) && !empty($target['method'])) {
+                $this->controller = $target['controller'];
+                $this->method = $target['method'];
             }
             else {
                 throw new \Exception('Target (array) of current route is incorrect');
             }
         }
         // if it's a string containing controller and method
-        else if (is_string($dispatchInfos)) {
+        else if (is_string($target)) {
             // Controller#method or Controller::method or Controller@method
             $availableSeparators = ['#', '::', '@'];
             $separatorFound = false;
             
             foreach ($availableSeparators as $currentSeparator) {
-                if (strpos($dispatchInfos, $currentSeparator) !== false) {
+                if (strpos($target, $currentSeparator) !== false) {
                     $separatorFound = true;
-                    $explodedInfos = explode($currentSeparator, $dispatchInfos);
+                    $explodedInfos = explode($currentSeparator, $target);
                     $this->controller = $explodedInfos[0];
                     $this->method = $explodedInfos[1];
 
@@ -64,12 +78,10 @@ class Dispatcher {
         else {
             throw new \Exception('Target of current route has incorrect type');
         }
-        
-        
     }
 
     /**
-     * Dispatch matched route
+     * Dispatches matched route
      *
      * @return void
      */

--- a/Dispatcher.php
+++ b/Dispatcher.php
@@ -77,8 +77,8 @@ class Dispatcher {
         if (!empty($this->controller) && !empty($this->method)) {
             // controller instanciation
             $controller = new $this->controller();
-            // method call
-            $controller->{$this->method}($this->params);
+            // method call with arguments unpacking
+            $controller->{$this->method}(...array_values($this->params));
         }
         else {
             throw new \Exception('Cannot dispatch : controller or method is empty');

--- a/README.md
+++ b/README.md
@@ -15,22 +15,15 @@ $router = new AltoRouter();
 
 // Map your routes
 $router->map( 'GET', '/', 'MainController::home', 'home' ); // MainController::home => AltoDispatcher will instanciate "MainController" and call its "home" method
-$router->map( 'GET', '/other-page', 'MainController::otherPage', 'home' ); // MainController::otherPage => AltoDispatcher will instanciate "MainController" and call its "otherPage" method
+$router->map( 'GET', '/other-page', 'MainController::otherPage', 'other-page' ); // MainController::otherPage => AltoDispatcher will instanciate "MainController" and call its "otherPage" method
 // [...]
+$match = $router->match();
 
-// If a route matches current URL
-if ($match) {
-    // You can optionnally add a try/catch here to handle Exceptions
-    // Instanciate the dispatcher
-    $dispatcher = new Dispatcher($match);
-    // then run the dispatch method which will call the mapped method
-    $dispatcher->dispatch();
-}
-else {
-    // 404
-    header('HTTP/1.0 404 Not Found');
-    echo '404'; // display your own 404 page (calling a method of a controller, for example ErrorController::404)
-}
+// You can optionnally add a try/catch here to handle Exceptions
+// Instanciate the dispatcher, give it the $match variable and a fallback action
+$dispatcher = new Dispatcher($match, 'ErrorController::err404');
+// then run the dispatch method which will call the mapped method
+$dispatcher->dispatch();
 ```
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,10 @@
 {
     "name": "benoclock/alto-dispatcher",
+    "version": "1.0.0",
     "description": "AltoDispatcher is a simple and easy-to-use class for dispatching after AltoRouter routing",
     "type": "library",
     "require": {
+        "php": ">=5.6.0",
         "altorouter/altorouter": "^1.2"
     },
     "license": "MIT",
@@ -12,5 +14,8 @@
             "email": "benjamin@oclock.io"
         }
     ],
+    "autoload": {
+        "classmap": ["Dispatcher.php"]
+    },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
Plus besoin de condition
```php
if ($match) {
    $dispatcher = new Dispatcher($match);
    $dispatcher->dispatch();
} else {
    header('HTTP/1.0 404 Not Found');
    // + gestion de l'affichage de la 404
```
À la place, on injecte la target de l'action 404 (même format que celles des routes) en deuxième paramètre du constructeur. Le Dispatcher se charge de placer le bon entête HTTP et de lancer l'action
```php
$dispatcher = new Dispatcher($match, 'ErrorController#err404');
$dispatcher->dispatch();
```